### PR TITLE
add missing 'notifiers' dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         'requests',
         'beautifulsoup4',
         'python-pushover',
+        'notifiers'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
fixes `ModuleNotFoundError: No module named 'notifiers'` when executing `medihunter` for the first time