### PR TITLE
set 'utf-8' encoding explicitly when opening search params json file

### DIFF
--- a/medicover_session.py
+++ b/medicover_session.py
@@ -319,7 +319,7 @@ def load_available_search_params(field_name):
 
     params_path = os.path.join(os.path.dirname(__file__), "ids/params.json")
 
-    with open(params_path) as f:
+    with open(params_path, encoding='utf-8') as f:
         params_file_content = f.read()
 
     params = json.loads(params_file_content)


### PR DESCRIPTION
fixes 
```
(.venv) λ medihunter show-params
Traceback (most recent call last):
  File "C:\Users\piotr\projects\medihunter\.venv\Scripts\medihunter-script.py", line 11, in <module>
    load_entry_point('medihunter', 'console_scripts', 'medihunter')()
  File "c:\users\piotr\projects\medihunter\.venv\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\piotr\projects\medihunter\.venv\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "c:\users\piotr\projects\medihunter\.venv\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\piotr\projects\medihunter\.venv\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\piotr\projects\medihunter\.venv\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "c:\users\piotr\projects\medihunter\medihunter.py", line 213, in show_params
    params = load_available_search_params(field_name)
  File "c:\users\piotr\projects\medihunter\medicover_session.py", line 323, in load_available_search_params
    params_file_content = f.read()
  File "C:\Users\piotr\AppData\Local\Programs\Python\Python38\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1304: character maps to <undefined>
```
when ran on Windows. No error found on Ubuntu 18.04 - either before or after setting encoding.