### PR TITLE
Możliwość użycia pliku .env z zapisanymi danymi logowania

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MEDICOVER_USER=login
+MEDICOVER_PASS=hasło

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ Przechodzimy do katalogu ze źródłem i odpalamy
 pip install --editable .
 ```
 
-Od teraz mamy dostępną w virtualenvie komendę **medihunter**
+Od teraz mamy dostępną w virtualenvie komendę: `medihunter`
+
+Jeśli nie chcemy być za każdym razem pytani o login i hasło i/lub nie chcemy podawać ich jawnie w terminalu poprzez `--user login --password hasło` to możemy zapisać je w pliku `.env`:
+```
+MEDICOVER_USER=login
+MEDICOVER_PASS=hasło
+```
+
+Najprościej skopiować przykładowy plik `.env.example` z głównego katalogu jako `.env` i uzupełnić w nim dane.
 
 ## Dostępne subkomendy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4==4.6.3
 python-pushover
 notifiers==1.0.3
 xmpppy==0.6.2
+python-dotenv=0.19.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
         'beautifulsoup4',
         'python-pushover',
         'notifiers',
-        'xmpppy'
+        'xmpppy',
+        'python-dotenv'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Jeśli nie chcemy być za każdym razem pytani o login i hasło i/lub nie chcemy podawać ich jawnie w terminalu poprzez `--user login --password hasło` to możemy zapisać je w pliku `.env`