### PR TITLE
Add support for MFA and cookie caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-pushover
 notifiers==1.0.3
 xmpppy==0.6.2
 python-dotenv=0.19.2
+appdirs==1.4.4

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
         'python-pushover',
         'notifiers',
         'xmpppy',
-        'python-dotenv'
+        'python-dotenv',
+        'appdirs'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Add missing authentication step for entering a second factor one time code from SMS and cache cookies to trigger this step only once and keep non-interactive functionality.