### PR TITLE
notification title for telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ opcja|domyślna wartość
 --pushover_user|brak, Pushover user Token
 --pushover_device|brak, None nazwa device w Pushover domyślnie pusta=wszystkie
 --pushover_msgtitle|brak - prefix dodawany przed tytułem powiadomienia
--t, --notification-title|brak, dostępna tylko w medihunter.py, wspierana tylko przez Pushover
+-t, --notification-title|brak, dostępna tylko w medihunter.py, wspierana tylko przez Pushover i Telegram
 
 ## Pushover w medihunter.py
 

--- a/medihunter.py
+++ b/medihunter.py
@@ -46,11 +46,11 @@ duplicate_checker = make_duplicate_checker()
 
 def notify_external_device(message: str, notifier: str, **kwargs):
     # TODO: add more notification providers
+    title = kwargs.get("notification_title")
     if notifier == "pushover":
-        title = kwargs.get("notification_title")
         pushover_notify(message, title)
     elif notifier == "telegram":
-        telegram_notify(message)
+        telegram_notify(message, title)
     elif notifier == "xmpp":
         xmpp_notify(message)
 

--- a/medihunter_notifiers.py
+++ b/medihunter_notifiers.py
@@ -20,8 +20,11 @@ def pushover_notify(message, title: str = None):
         print(f'Pushover notification failed:\n{r.errors}')
 
 
-def telegram_notify(message):
+def telegram_notify(message, title: str = None):
     try:
+        if title:
+            message = f"<b>{title}</b>\n{message}"
+
         r = telegram.notify(message=message,
                             parse_mode='html')
     except BadArguments as e:


### PR DESCRIPTION
when searching for few appointments types and using telegram as notification target users are not able to differentiate from which search they get notification - this PR extend telegram notification by notification title