### PR TITLE
Fixing today date format

### DIFF
--- a/medihunter.py
+++ b/medihunter.py
@@ -20,7 +20,7 @@ from medihunter_notifiers import pushover_notify, telegram_notify, xmpp_notify
 
 load_dotenv()
 now = datetime.now()
-now_formatted = now.strftime("%Y-%m-%dT02:00:00.000Z")
+now_formatted = now.strftime("%Y-%m-%d")
 
 
 def make_duplicate_checker() -> Callable[[Appointment], bool]:


### PR DESCRIPTION
Use of -f (end-date) parameter ends with an error when no proper -d (start-date) is specified as well, because a default value for -d has a wrong format  ("%Y-%m-%dT02:00:00.000Z" instead of "%Y-%m-%d"). Error is caused by:

`    if end_date:
        start_date_dt = datetime.strptime(start_date, "%Y-%m-%d")`

where a format mismatch occurs. 
