### PR TITLE
Improvements for my-appointments command

### DIFF
--- a/medicover_session.py
+++ b/medicover_session.py
@@ -19,7 +19,7 @@ USER_AGENT = ua.random
 
 Appointment = namedtuple(
     "Appointment",
-    ["doctor_name", "clinic_name", "appointment_datetime", "is_phone_consultation"],
+    ["doctor_name", "clinic_name", "specialization_name", "appointment_datetime", "is_phone_consultation"],
 )
 
 
@@ -233,6 +233,7 @@ class MedicoverSession:
         appointment = Appointment(
             doctor_name=r["doctorName"],
             clinic_name=r["clinicName"],
+            specialization_name=r["specializationName"].strip(),
             appointment_datetime=r["appointmentDate"],
             is_phone_consultation=r["isPhoneConsultation"],
         )

--- a/medicover_session.py
+++ b/medicover_session.py
@@ -1,7 +1,7 @@
 import json
 import os
 import pickle
-from collections import namedtuple
+from collections import namedtuple, deque
 from datetime import datetime, timedelta
 
 import appdirs
@@ -387,7 +387,7 @@ class MedicoverSession:
 
     def get_appointments(self):
         """Download all past and future appointments."""
-        appointments = []
+        appointments = deque()
         page = 1
         while True:
             response = self.session.post(
@@ -407,14 +407,14 @@ class MedicoverSession:
             response.raise_for_status()
             response_json = response.json()
             for r in response_json["items"]:
-                appointments.append(self.convert_search_result_to_appointment(r))
+                appointments.appendleft(self.convert_search_result_to_appointment(r))
             if len(appointments) >= response_json["totalCount"]:
                 break
             # Just in case the condition above fails for some reason.
             if not len(response_json["items"]):
                 break
             page += 1
-        return appointments
+        return list(appointments)
 
 
 def load_available_search_params(field_name):

--- a/medicover_session.py
+++ b/medicover_session.py
@@ -385,7 +385,7 @@ class MedicoverSession:
 
         return output
 
-    def get_appointments(self):
+    def get_appointments(self, not_before):
         """Download all past and future appointments."""
         appointments = deque()
         page = 1
@@ -406,8 +406,15 @@ class MedicoverSession:
             )
             response.raise_for_status()
             response_json = response.json()
+            finish = False
             for r in response_json["items"]:
-                appointments.appendleft(self.convert_search_result_to_appointment(r))
+                appointment = self.convert_search_result_to_appointment(r)
+                if datetime.strptime(appointment.appointment_datetime, "%Y-%m-%dT%H:%M:%S") < not_before:
+                    finish = True
+                    break
+                appointments.appendleft(appointment)
+            if finish:
+                break
             if len(appointments) >= response_json["totalCount"]:
                 break
             # Just in case the condition above fails for some reason.

--- a/medihunter.py
+++ b/medihunter.py
@@ -81,10 +81,11 @@ def process_appointments(
         )
 
 
-def echo_appointment(appointment):
+def echo_appointment(appointment, verbose=False):
     click.echo(
         appointment.appointment_datetime
         + " "
+        + (click.style(appointment.specialization_name + " ", fg="bright_blue") if verbose else "")
         + click.style(appointment.doctor_name, fg="bright_green")
         + " "
         + appointment.clinic_name
@@ -270,7 +271,7 @@ def my_appointments(show_past, user, password):
             click.echo("Showing only planned appointments:")
 
     for appointment in appointments:
-        echo_appointment(appointment)
+        echo_appointment(appointment, verbose=True)
 
 
 @click.group()

--- a/medihunter.py
+++ b/medihunter.py
@@ -257,13 +257,9 @@ def my_appointments(show_past, user, password):
     med_session = login(user, password)
     if not med_session:
         return
-    appointments = med_session.get_appointments()
+    appointments = med_session.get_appointments(datetime.fromtimestamp(0) if show_past else now)
 
     if not show_past:
-        appointments = list(filter(lambda a: datetime.strptime(
-            a.appointment_datetime, "%Y-%m-%dT%H:%M:%S"
-        ) >= now, appointments))
-
         if not appointments:
             click.echo("No planned appointments.")
             pass

--- a/medihunter.py
+++ b/medihunter.py
@@ -249,23 +249,28 @@ def login(user, password):
 
 
 @click.command()
+@click.option("--show-past", default=False, is_flag=True, help='Also show past appointments')
 @click.option("--user", prompt=True, envvar='MEDICOVER_USER')
 @click.password_option(confirmation_prompt=False, envvar='MEDICOVER_PASS')
-def my_appointments(user, password):
+def my_appointments(show_past, user, password):
     med_session = login(user, password)
     if not med_session:
         return
     appointments = med_session.get_appointments()
 
-    planned_appointments = list(filter(lambda a: datetime.strptime(
-        a.appointment_datetime, "%Y-%m-%dT%H:%M:%S"
-    ) >= now, appointments))
-    if planned_appointments:
-        click.echo("Showing only planned appointments:")
-        for planned_appointment in planned_appointments:
-            echo_appointment(planned_appointment)
-    else:
-        click.echo("No planned appointments.")
+    if not show_past:
+        appointments = list(filter(lambda a: datetime.strptime(
+            a.appointment_datetime, "%Y-%m-%dT%H:%M:%S"
+        ) >= now, appointments))
+
+        if not appointments:
+            click.echo("No planned appointments.")
+            pass
+        else:
+            click.echo("Showing only planned appointments:")
+
+    for appointment in appointments:
+        echo_appointment(appointment)
 
 
 @click.group()


### PR DESCRIPTION
- add `--show-past` option to enable display of past appointments
- show doctor specialization in results
- show list appointments in ascending time order, not descending
- optimize by moving time filtering to the method of `MedicoverSession`