### PR TITLE
remove copy ids from dockerfile as not used anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM python:alpine3.17
 
 WORKDIR /app/
 
-COPY ids ids
-
 COPY ["medicover_session.py" ,"medihunter*.py", "setup.py", "/app/"]
 
 # Workaround for "use_2to3 is invalid" error


### PR DESCRIPTION
Instrukcja przez którą failuje build dockerowego obrazu.
> Step 3/7 : COPY ids ids
> COPY failed: file not found in build context or excluded by .dockerignore: stat ids: file does not exist

W historii repo widać, że kiedyś `ids` zawierało idki regionów, lekarzy itp., ale z tego co widzę, to już nie są potrzebne i listujemy je sami.