### PR TITLE
package bump of Click and notifiers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Click==7.0
+Click==8.1.7
 requests==2.31.0
 beautifulsoup4==4.6.3
-notifiers==1.0.3
+notifiers==1.3.3
 xmpppy==0.6.2
 python-dotenv==0.19.2
 appdirs==1.4.4


### PR DESCRIPTION
Bump of notifiers to 1.3.3 since requests in new version won't work with old version of notifiers.
Bump of Click to 8.1.7 because new notifiers won't work with old version of Click.